### PR TITLE
Run apt-get update before installing packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,9 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Install dependent packages
-        run: sudo apt-get install gcc-aarch64-linux-gnu gcc-arm-linux-gnueabi{,hf} libelf-dev
+        run: |
+          sudo apt-get update
+          sudo apt-get install gcc-aarch64-linux-gnu gcc-arm-linux-gnueabi{,hf} libelf-dev
 
       # Runs a set of commands using the runners shell
       - name: Make ${{ matrix.mainboard }} kernel


### PR DESCRIPTION
Without running apt-get update, you get error messages about packages
not being found.

Signed-off-by: Ryan O'Leary <ryanoleary@google.com>